### PR TITLE
Automatically enable `@babel/plugin-transform-react-jsx`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @ungap/babel-plugin-transform-hinted-jsx
 
-This plugin is [a follow up of this post](https://webreflection.medium.com/jsx-is-inefficient-by-default-but-d1122c992399) and it can be used together with [@babel/plugin-transform-react-jsx](https://www.npmjs.com/package/@babel/plugin-transform-react-jsx).
+This plugin is [a follow up of this post](https://webreflection.medium.com/jsx-is-inefficient-by-default-but-d1122c992399) and it can be used in place of [@babel/plugin-transform-react-jsx](https://www.npmjs.com/package/@babel/plugin-transform-react-jsx).
 
 A huge thanks to [Nicolò Ribaudo](https://twitter.com/NicoloRibaudo) for helping out.
 
@@ -9,7 +9,6 @@ A huge thanks to [Nicolò Ribaudo](https://twitter.com/NicoloRibaudo) for helpin
 ```json
 {
   "plugins": [
-    ["@babel/plugin-transform-react-jsx", {"useSpread": true}],
     ["@ungap/babel-plugin-transform-hinted-jsx"]
   ]
 }
@@ -20,7 +19,6 @@ A huge thanks to [Nicolò Ribaudo](https://twitter.com/NicoloRibaudo) for helpin
 ```sh
 npm i --save-dev @babel/cli
 npm i --save-dev @babel/core
-npm i --save-dev @babel/plugin-transform-react-jsx
 npm i --save-dev @ungap/plugin-transform-hinted-jsx
 ```
 

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,6 +1,5 @@
 {
   "plugins": [
-    ["@babel/plugin-transform-react-jsx", {"useSpread": true}],
-    ["./esm/index.js"]
+    "./esm/index.js"
   ]
 }

--- a/cjs/index.js
+++ b/cjs/index.js
@@ -1,9 +1,14 @@
 'use strict';
+const _pluginJSX = (m => /* c8 ignore start */ m.__esModule ? m.default : m /* c8 ignore stop */)(require("@babel/plugin-transform-react-jsx"));
+// _pluginJSX.default when using native ESM;
+// _pluginJSX when using the version compiled by ascjs.
+const pluginJSX = _pluginJSX.default || _pluginJSX;
+
 const JSX_ANNOTATION_REGEX = /\*?\s*@jsx\s+([^\s]+)/;
 const JSX_FRAG_ANNOTATION_REGEX = /\*?\s*@jsxFrag\s+([^\s]+)/;
 const JSX_INTERPOLATION_ANNOTATION_REGEX = /\*?\s*@jsxInterpolation\s+([^\s]+)/;
 
-module.exports = ({types: t}) => {
+module.exports = ({types: t}, options) => {
   let pragma = '', pragmaFrag = '', pragmaPrefix = '', pragmaInterpolation = '';
 
   const interpolation = () => {
@@ -28,7 +33,11 @@ module.exports = ({types: t}) => {
     );
   }
 
+  // Force the JSX plugin to use object spread instead of _extends.
+  options.useSpread = true;
+
   return {
+    inherits: pluginJSX,
     visitor: {
       Program: {
         enter(_, state) {

--- a/esm/index.js
+++ b/esm/index.js
@@ -1,8 +1,13 @@
+import _pluginJSX from "@babel/plugin-transform-react-jsx";
+// _pluginJSX.default when using native ESM;
+// _pluginJSX when using the version compiled by ascjs.
+const pluginJSX = _pluginJSX.default || _pluginJSX;
+
 const JSX_ANNOTATION_REGEX = /\*?\s*@jsx\s+([^\s]+)/;
 const JSX_FRAG_ANNOTATION_REGEX = /\*?\s*@jsxFrag\s+([^\s]+)/;
 const JSX_INTERPOLATION_ANNOTATION_REGEX = /\*?\s*@jsxInterpolation\s+([^\s]+)/;
 
-export default ({types: t}) => {
+export default ({types: t}, options) => {
   let pragma = '', pragmaFrag = '', pragmaPrefix = '', pragmaInterpolation = '';
 
   const interpolation = () => {
@@ -27,7 +32,11 @@ export default ({types: t}) => {
     );
   }
 
+  // Force the JSX plugin to use object spread instead of _extends.
+  options.useSpread = true;
+
   return {
+    inherits: pluginJSX,
     visitor: {
       Program: {
         enter(_, state) {

--- a/package.json
+++ b/package.json
@@ -24,10 +24,15 @@
     },
     "./package.json": "./package.json"
   },
+  "dependencies": {
+    "@babel/plugin-transform-react-jsx": "^7.19.0"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
+  },
   "devDependencies": {
     "@babel/cli": "^7.19.3",
     "@babel/core": "^7.19.3",
-    "@babel/plugin-transform-react-jsx": "^7.19.0",
     "ascjs": "^5.0.1"
   },
   "description": "A JSX transformer with extra hints around interpolations and outer templates",


### PR DESCRIPTION
By inheriting from `@babel/plugin-transform-react-jsx`, users don't have to manually enable it in their config.