### PR TITLE
Fix transformation of `JSXExpressionContainer`

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
-    ["./esm/index.js"],
-    ["@babel/plugin-transform-react-jsx", {"useSpread": true}]
+    ["@babel/plugin-transform-react-jsx", {"useSpread": true}],
+    ["./esm/index.js"]
   ]
 }

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
-    ["@babel/plugin-transform-react-jsx", {"useSpread": true}],
-    ["./esm/index.js"]
+    ["./esm/index.js"],
+    ["@babel/plugin-transform-react-jsx", {"useSpread": true}]
   ]
 }

--- a/esm/index.js
+++ b/esm/index.js
@@ -127,17 +127,15 @@ export default ({types: t}) => {
       return array;
     }
 
-    const value = convertAttributeValue(
-      attribute.node.name.name !== "key"
-        ? attribute.node.value || t.booleanLiteral(true)
-        : attribute.node.value,
-    );
-
-    if (attribute.node.name.name === "key" && value === null) {
+    if (attribute.node.name.name === "key" && attribute.node.value === null) {
       throw attribute.buildCodeFrameError(
         'Please provide an explicit key value. Using "key" as a shorthand for "key={true}" is not allowed.',
       );
     }
+
+    const value = t.isJSXExpressionContainer(attribute.node.value)
+      ? attribute.node.value.expression
+      : attribute.node.value || t.booleanLiteral(true);
 
     if (
       t.isStringLiteral(value) &&
@@ -168,15 +166,6 @@ export default ({types: t}) => {
       ),
     );
     return array;
-  }
-
-  function convertAttributeValue(node) {
-    return t.isJSXExpressionContainer(node) ?
-      t.callExpression(
-        toMemberExpression(interpolation()),
-        [node.expression]
-      ) :
-      node;
   }
 
   function convertJSXIdentifier(node, parent) {

--- a/esm/index.js
+++ b/esm/index.js
@@ -14,22 +14,65 @@ export default ({types: t}) => {
 
   return {
     visitor: {
-      Program: {
-        enter(_, state) {
-          const {file: {ast: {comments}}} = state;
-          if (comments) {
-            for (const comment of comments) {
-              if (JSX_ANNOTATION_REGEX.test(comment.value)) {
-                pragma = RegExp.$1;
-                [pragmaPrefix] = pragma.split('.');
-              }
-              else if (JSX_FRAG_ANNOTATION_REGEX.test(comment.value))
-                pragmaFrag = RegExp.$1;
-              else if (JSX_INTERPOLATION_ANNOTATION_REGEX.test(comment.value))
-                pragmaInterpolation = RegExp.$1;
+      Program(path, state) {
+        const {file: {ast: {comments}}} = state;
+        if (comments) {
+          for (const comment of comments) {
+            if (JSX_ANNOTATION_REGEX.test(comment.value)) {
+              pragma = RegExp.$1;
+              [pragmaPrefix] = pragma.split('.');
             }
+            else if (JSX_FRAG_ANNOTATION_REGEX.test(comment.value))
+              pragmaFrag = RegExp.$1;
+            else if (JSX_INTERPOLATION_ANNOTATION_REGEX.test(comment.value))
+              pragmaInterpolation = RegExp.$1;
           }
         }
+
+        path.traverse({
+          JSXExpressionContainer(path) {
+            const {expression} = path.node;
+
+            path.node.expression = t.callExpression(
+              toMemberExpression(interpolation()),
+              [expression]
+            );
+          },
+          JSXElement: {
+            exit(path) {
+              if (!path.parentPath.isJSX() && !path.parentPath.isCallExpression()) {
+                const openingPath = path.get('openingElement');
+                const attributes = openingPath.get('attributes');
+                const callExpr = t.callExpression(
+                  toMemberExpression((pragma || 'React.createElement') + '``'),
+                  [
+                    getTag(openingPath),
+                    attributes.length ?
+                      t.objectExpression(attributes.reduce(accumulateAttribute, [])) :
+                      t.nullLiteral(),
+                    ...t.react.buildChildren(path.node),
+                  ]
+                );
+                path.replaceWith(t.inherits(callExpr, path.node));
+              }
+            }
+          },
+          JSXFragment: {
+            exit(path) {
+              if (!path.parentPath.isJSX() && !path.parentPath.isCallExpression()) {
+                const callExpr = t.callExpression(
+                  toMemberExpression((pragma || 'React.createElement') + '``'),
+                  [
+                    toMemberExpression(pragmaFrag || 'React.Fragment'),
+                    t.nullLiteral(),
+                    ...t.react.buildChildren(path.node)
+                  ]
+                );
+                path.replaceWith(t.inherits(callExpr, path.node));
+              }
+            }
+          }
+        })
       },
       FunctionDeclaration(path) {
         if (path.node.id.name === '_extends' && path.parentPath.type === 'Program') {
@@ -59,48 +102,6 @@ export default ({types: t}) => {
                 path.parentPath
               )
             );
-          }
-        }
-      },
-      JSXExpressionContainer(path) {
-        const {expression} = path.node;
-
-        path.node.expression = t.callExpression(
-          toMemberExpression(interpolation()),
-          [expression]
-        );
-      },
-      JSXElement: {
-        exit(path) {
-          if (!path.parentPath.isJSX() && !path.parentPath.isCallExpression()) {
-            const openingPath = path.get('openingElement');
-            const attributes = openingPath.get('attributes');
-            const callExpr = t.callExpression(
-              toMemberExpression((pragma || 'React.createElement') + '``'),
-              [
-                getTag(openingPath),
-                attributes.length ?
-                  t.objectExpression(attributes.reduce(accumulateAttribute, [])) :
-                  t.nullLiteral(),
-                ...t.react.buildChildren(path.node),
-              ]
-            );
-            path.replaceWith(t.inherits(callExpr, path.node));
-          }
-        }
-      },
-      JSXFragment: {
-        exit(path) {
-          if (!path.parentPath.isJSX() && !path.parentPath.isCallExpression()) {
-            const callExpr = t.callExpression(
-              toMemberExpression((pragma || 'React.createElement') + '``'),
-              [
-                toMemberExpression(pragmaFrag || 'React.Fragment'),
-                t.nullLiteral(),
-                ...t.react.buildChildren(path.node)
-              ]
-            );
-            path.replaceWith(t.inherits(callExpr, path.node));
           }
         }
       }

--- a/esm/index.js
+++ b/esm/index.js
@@ -12,6 +12,8 @@ export default ({types: t}) => {
     );
   };
 
+  const transformedJSXContainers = new WeakSet();
+
   return {
     visitor: {
       Program(path, state) {
@@ -30,12 +32,13 @@ export default ({types: t}) => {
         }
 
         path.traverse({
-          JSXExpressionContainer(path) {
-            const {expression} = path.node;
+          JSXExpressionContainer({ node }) {
+            if (transformedJSXContainers.has(node)) return;
+            transformedJSXContainers.add(node);
 
-            path.node.expression = t.callExpression(
+            node.expression = t.callExpression(
               toMemberExpression(interpolation()),
-              [expression]
+              [node.expression]
             );
           },
           JSXElement: {

--- a/test/input.jsx
+++ b/test/input.jsx
@@ -16,3 +16,21 @@ function Component({ className, props, others }) {
     </>
   );
 }
+
+function Interoplation() {
+  const f1 = (
+    <>
+      A
+      {first}
+      B
+    </>
+  );
+
+  const f2 = (
+    <div>
+      A
+      {second}
+      B
+    </div>
+  );
+}

--- a/test/output.js
+++ b/test/output.js
@@ -22,7 +22,7 @@ function Component({
     ...others
   }), test.interpolation([test.createElement``("p", {
     a: "a",
-    b: test.interpolation(test.interpolation(Math.random() < .5))
+    b: test.interpolation(Math.random() < .5)
   })])));
 }
 

--- a/test/output.js
+++ b/test/output.js
@@ -10,20 +10,20 @@ function Component({
 }) {
   return test.createElement``(test.Fragment, null, test.createElement("div", {
     id: "my-div",
-    className: test.interpolation(test.interpolation(className))
+    className: test.interpolation(className)
   }, test.createElement(test.Fragment, null, test.createElement("span", null), "OK"), test.createElement("p", {
-    color: test.interpolation(test.interpolation(color)),
+    color: test.interpolation(color),
     label: "f\"o",
-    hidden: test.interpolation(test.interpolation(Math.random() < .5))
+    hidden: test.interpolation(Math.random() < .5)
   })), test.createElement(Component, test.interpolation({
     id: "my-component",
-    className: test.interpolation(test.interpolation(className)),
+    className: test.interpolation(className),
     ...props,
     ...others
-  }), test.interpolation(test.interpolation([test.createElement``("p", {
+  }), test.interpolation([test.createElement``("p", {
     a: "a",
     b: test.interpolation(test.interpolation(Math.random() < .5))
-  })]))));
+  })])));
 }
 
 function Interoplation() {

--- a/test/output.js
+++ b/test/output.js
@@ -22,6 +22,11 @@ function Component({
     ...others
   }), test.interpolation([test.createElement``("p", {
     a: "a",
-    b: test.interpolation(Math.random() < .5)
+    b: test.interpolation(test.interpolation(Math.random() < .5))
   })])));
+}
+
+function Interoplation() {
+  const f1 = test.createElement``(test.Fragment, null, "A", test.interpolation(first), "B");
+  const f2 = test.createElement``("div", null, "A", test.interpolation(second), "B");
 }

--- a/test/output.js
+++ b/test/output.js
@@ -10,20 +10,20 @@ function Component({
 }) {
   return test.createElement``(test.Fragment, null, test.createElement("div", {
     id: "my-div",
-    className: test.interpolation(className)
+    className: test.interpolation(test.interpolation(className))
   }, test.createElement(test.Fragment, null, test.createElement("span", null), "OK"), test.createElement("p", {
-    color: test.interpolation(color),
+    color: test.interpolation(test.interpolation(color)),
     label: "f\"o",
-    hidden: test.interpolation(Math.random() < .5)
+    hidden: test.interpolation(test.interpolation(Math.random() < .5))
   })), test.createElement(Component, test.interpolation({
     id: "my-component",
-    className: test.interpolation(className),
+    className: test.interpolation(test.interpolation(className)),
     ...props,
     ...others
-  }), test.interpolation([test.createElement``("p", {
+  }), test.interpolation(test.interpolation([test.createElement``("p", {
     a: "a",
     b: test.interpolation(test.interpolation(Math.random() < .5))
-  })])));
+  })]))));
 }
 
 function Interoplation() {


### PR DESCRIPTION
This PR can be reviewed commit-by-commit, to more easily understand what's going on.

1. **[Transform JSX elements in bottom-up order](https://github.com/ungap/babel-plugin-transform-hinted-jsx/commit/6bea817b5ebf656c219cb889ff125e469d20c599)**
   When transforming an element, its contents are converted to the arguments of the call expression and thus `JSXExpressionContainer` nodes are unwrapped.
   If we transform the AST while traversing it in top-down order (where the top is `Program`), the `JSXExpressionContainer` visitor will not find the `JSXExpressionContainer` nodes because they have been removed at the step before. Instead, we can transform the AST while traversing it in the opposite order: first we transform `JSXExpressionContainer`s, and then their outer `JSXElement`s/`JSXFragment`s. This is similar to how it's done in the JSX transform: https://github.com/babel/babel/blob/0b0f083c777bf59b197467b973d6418325c5ddd7/packages/babel-plugin-transform-react-jsx/src/create-plugin.ts#L284
2. **[Transform in Program visitor to avoid relying on plugins order](https://github.com/ungap/babel-plugin-transform-hinted-jsx/commit/1d1811573163f9ba7f1c9a60ade61384f7142ccf)**
   Since now this plugin transforms JSX elements in the same visitor as the main JSX plugin, users would be responsible of making sure that this plugin is listed _before_ the JSX one in their config, so that it visits those nodes first. We can avoid this configuration burden by running our transform when visiting `Program`, so that it always happens before that the main JSX plugins traverses the JSX nodes.
3. **[Avoid double interoplation wrap](https://github.com/ungap/babel-plugin-transform-hinted-jsx/commit/9e6deb033d8b8c7ace47150aece2e9597521a125)**
   Transforming during the bottom-up traversal has a problem: since Babel requeues replaced nodes (so that they can be re-transformed by other plugins), we traverse `JSXExpressionContainer`s twice:
   - First traversal, we go down to the leaves and visit the `JSXExpressionContainer` nodes
   - While going up, Babel transforms top-level fragments/elements, and they are requeued
   - Since they have been requeued, Babel re-traverses them, visiting again the `JSXExpressionContainer` nodes
 
   We can avoid wrapping then twice in `React.interpolation` by keeping track of what we already wrapped.